### PR TITLE
Fix #11 (memory leak) and #52 ("gl_" are reserved)

### DIFF
--- a/NonEuclidean/FrameBuffer.cpp
+++ b/NonEuclidean/FrameBuffer.cpp
@@ -33,6 +33,13 @@ FrameBuffer::FrameBuffer() {
   glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
 }
 
+FrameBuffer::~FrameBuffer()
+{
+  glDeleteRenderbuffersEXT(1, &renderBuf);
+  glDeleteFramebuffersEXT(1, &fbo);
+  glDeleteTextures(1, &texId);
+}
+
 void FrameBuffer::Use() {
   glBindTexture(GL_TEXTURE_2D, texId);
 }

--- a/NonEuclidean/FrameBuffer.h
+++ b/NonEuclidean/FrameBuffer.h
@@ -8,7 +8,7 @@ class Portal;
 class FrameBuffer {
 public:
   FrameBuffer();
-
+  ~FrameBuffer();
   void Render(const Camera& cam, GLuint curFBO, const Portal* skipPortal);
   void Use();
 

--- a/NonEuclidean/Shaders/pink.frag
+++ b/NonEuclidean/Shaders/pink.frag
@@ -5,8 +5,8 @@ precision highp float;
 uniform sampler2D tex;
 
 //Outputs
-out vec4 gl_FragColor;
+out vec4 FragColor;
 
 void main(void) {
-	gl_FragColor = vec4(1.0, 0.0, 1.0, 1.0);
+	FragColor = vec4(1.0, 0.0, 1.0, 1.0);
 }

--- a/NonEuclidean/Shaders/portal.frag
+++ b/NonEuclidean/Shaders/portal.frag
@@ -6,10 +6,10 @@ uniform sampler2D tex;
 in vec4 ex_uv;
 
 //Outputs
-out vec4 gl_FragColor;
+out vec4 FragColor;
 
 void main(void) {
 	vec2 uv = (ex_uv.xy / ex_uv.w);
 	uv = uv*0.5 + 0.5;
-	gl_FragColor = vec4(texture2D(tex, uv).rgb, 1.0);
+	FragColor = vec4(texture2D(tex, uv).rgb, 1.0);
 }

--- a/NonEuclidean/Shaders/sky.frag
+++ b/NonEuclidean/Shaders/sky.frag
@@ -9,7 +9,7 @@ precision highp float;
 in vec3 ex_normal;
 
 //Outputs
-out vec4 gl_FragColor;
+out vec4 FragColor;
 
 void main(void) {
 	vec3 n = normalize(ex_normal);
@@ -20,5 +20,5 @@ void main(void) {
 	float s = dot(n, LIGHT) - 1.0 + SUN_SIZE;
 	float sun = min(exp(s * SUN_SHARPNESS / SUN_SIZE), 1.0);
 	
-	gl_FragColor = vec4(max(sky, sun), 1.0);
+	FragColor = vec4(max(sky, sun), 1.0);
 }

--- a/NonEuclidean/Shaders/texture.frag
+++ b/NonEuclidean/Shaders/texture.frag
@@ -9,9 +9,9 @@ in vec2 ex_uv;
 in vec3 ex_normal;
 
 //Outputs
-out vec4 gl_FragColor;
+out vec4 FragColor;
 
 void main(void) {
 	float s = dot(ex_normal, LIGHT)*0.5 + 0.5;
-	gl_FragColor = vec4(texture(tex, ex_uv).rgb * s, 1.0);
+	FragColor = vec4(texture(tex, ex_uv).rgb * s, 1.0);
 }

--- a/NonEuclidean/Shaders/texture_array.frag
+++ b/NonEuclidean/Shaders/texture_array.frag
@@ -9,9 +9,9 @@ in vec3 ex_uv;
 in vec3 ex_normal;
 
 //Outputs
-out vec4 gl_FragColor;
+out vec4 FragColor;
 
 void main(void) {
 	float s = dot(ex_normal, LIGHT)*0.25 + 0.75;
-	gl_FragColor = vec4(texture(tex, ex_uv).rgb * s, 1.0);
+	FragColor = vec4(texture(tex, ex_uv).rgb * s, 1.0);
 }

--- a/NonEuclidean/Texture.cpp
+++ b/NonEuclidean/Texture.cpp
@@ -64,6 +64,11 @@ Texture::Texture(const char* fname, int rows, int cols) {
   delete[] img;
 }
 
+Texture::~Texture()
+{
+  glDeleteTextures(1, &texId);
+}
+
 void Texture::Use() {
   if (is3D) {
     glBindTexture(GL_TEXTURE_2D_ARRAY, texId);

--- a/NonEuclidean/Texture.h
+++ b/NonEuclidean/Texture.h
@@ -4,7 +4,7 @@
 class Texture {
 public:
   Texture(const char* fname, int rows, int cols);
-
+  ~Texture();
   void Use();
 
 private:


### PR DESCRIPTION
Fix #11 (memory leak)  and #52 (identifiers starting with "gl_" are reserved).
Added destructors of FrameBuffer and Texture to release OpenGL resources properly.
Renamed `gl_FragColor` to `FragColor` for consistency with OpenGL naming conventions.
Hope to be helpful to you : )