### PR TITLE
Add meson build project

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,41 @@
+project('NonEuclidean', 'cpp', default_options: ['warning_level=3', 'cpp_std=c++14'])
+
+gl_dep = dependency('gl')
+
+glew_dep = dependency('glew', method: 'pkg-config', required: false)
+if not glew_dep.found()
+  glew_dep = dependency('glew', static: true, required: true)
+endif
+
+game_objects_src = [
+  'NonEuclidean/Player.cpp',
+  'NonEuclidean/Portal.cpp',
+]
+scenes_src = [
+  'NonEuclidean/Level1.cpp',
+  'NonEuclidean/Level2.cpp',
+  'NonEuclidean/Level3.cpp', 
+  'NonEuclidean/Level4.cpp', 
+  'NonEuclidean/Level5.cpp', 
+  'NonEuclidean/Level6.cpp',
+]
+engine_src = [
+  'NonEuclidean/Camera.cpp',
+  'NonEuclidean/Collider.cpp',
+  'NonEuclidean/Engine.cpp',
+  'NonEuclidean/FrameBuffer.cpp',
+  'NonEuclidean/Input.cpp',
+  'NonEuclidean/Main.cpp',
+  'NonEuclidean/Mesh.cpp',
+  'NonEuclidean/Object.cpp',
+  'NonEuclidean/Physical.cpp',
+  'NonEuclidean/Resources.cpp',
+  'NonEuclidean/Shader.cpp',
+  'NonEuclidean/Texture.cpp',
+]
+
+executable('NonEuclidean',
+  dependencies: [gl_dep, glew_dep],
+  include_directories: include_directories('NonEuclidean'),
+  gui_app: true,
+  sources: game_objects_src + scenes_src + engine_src)

--- a/subprojects/glew.wrap
+++ b/subprojects/glew.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = glew-2.2.0
+source_url = http://downloads.sourceforge.net/glew/glew-2.2.0.tgz
+source_filename = glew-2.2.0.tgz
+source_hash = d4fc82893cfb00109578d0a1a2337fb8ca335b3ceccf97b97e5cc7f08e4353e1
+patch_filename = glew_2.2.0-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/glew_2.2.0-2/get_patch
+patch_hash = df7bc80456da53f83e93e89ca5035d04cdff19a836c956887a684b2bee16eb9b
+wrapdb_version = 2.2.0-2
+
+[provide]
+glew = glew_dep


### PR DESCRIPTION
Probably not that interesting but as I had a bit of trouble on building the project and retrieving `glew`, thought this maybe could be useful for others also as no longer installing glew is needed using this and this can pave the way to make the project cross platform, just using `winget` that is available in Windows machines and issuing this on the command line,

```
winget install meson
meson setup build
meson compile -C build
cd NonEuclidean
..\build\NonEuclidean.exe
```